### PR TITLE
Fix movies API and JSON helper

### DIFF
--- a/client/src/hooks/global.jsx
+++ b/client/src/hooks/global.jsx
@@ -1,7 +1,15 @@
 import { useEffect, useState } from "react";
 
-export async function fetchJSON(url) {
-  const res = await fetch(url);
+export async function fetchJSON(url, options = {}) {
+  const { json, ...fetchOptions } = options;
+  if (json !== undefined) {
+    fetchOptions.headers = {
+      "Content-Type": "application/json",
+      ...(fetchOptions.headers || {}),
+    };
+    fetchOptions.body = JSON.stringify(json);
+  }
+  const res = await fetch(url, fetchOptions);
   if (!res.ok) {
     throw new Error(`Failed ${res.status}`);
   }

--- a/server/moviesApi.js
+++ b/server/moviesApi.js
@@ -32,12 +32,12 @@ export function MoviesApi(mongoDatabase) {
     res.json(movies);
   });
 
-  router.post("/", (req, res) => {
+  router.post("/", async (req, res) => {
     const { title } = req.body;
-    mongoDatabase.collection(movies).insertOne({
+    await mongoDatabase.collection("movies").insertOne({
       title,
     });
-    res.sendStatus(204);
+    res.sendStatus(201);
   });
 
   router.get("/search/*", async (req, res) => {
@@ -70,8 +70,8 @@ export function MoviesApi(mongoDatabase) {
       }))
       .limit(50)
       .toArray();
-    if (!movies) {
-      res.status(404).json({ errors });
+    if (!movies || movies.length === 0) {
+      res.status(404).json({ error: "Not found" });
       return;
     }
     res.json({ movies });


### PR DESCRIPTION
## Summary
- support request options in client `fetchJSON`
- insert new movies correctly and return 201
- return clear error if movies not found

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f5cfd814c8332af9ba8d5907b3589